### PR TITLE
Handle custom sreg attribute namespaces

### DIFF
--- a/Vendor/lightopenid/openid.php
+++ b/Vendor/lightopenid/openid.php
@@ -794,8 +794,18 @@ class LightOpenID
     {
         $attributes = array();
         $sreg_to_ax = array_flip(self::$ax_to_sreg);
+
+        $ns = 'sreg';
+        foreach ($this->data as $key => $val) {
+            if (substr($key, 0, strlen('openid_ns_')) == 'openid_ns_'
+                && $val == 'http://openid.net/extensions/sreg/1.1') {
+                $ns = substr($key, strlen('openid_ns_'));
+                break;
+            }
+        }
+
         foreach (explode(',', $this->data['openid_signed']) as $key) {
-            $keyMatch = 'sreg.';
+            $keyMatch = $ns . '.';
             if (substr($key, 0, strlen($keyMatch)) != $keyMatch) {
                 continue;
             }
@@ -804,7 +814,7 @@ class LightOpenID
                 # The field name isn't part of the SREG spec, so we ignore it.
                 continue;
             }
-            $attributes[$sreg_to_ax[$key]] = $this->data['openid_sreg_' . $key];
+            $attributes[$sreg_to_ax[$key]] = $this->data['openid_' . $ns . '_' . $key];
         }
         return $attributes;
     }


### PR DESCRIPTION
A namespace attribute was currently only supported for ax attributes. If
a namespace was used with sreg attributes the openid provider was unable
to find the attributes.

This was the case when using the openid provider with an Atlassian Crowd
Server (respectively Atlassian CrowdID), which was using a sreg
namespace.

The default namespace remains 'sreg'. If the response from the
OpenID server contains an item with the key 'openid_ns_<namespace>' and
the value 'http://openid.net/extensions/sreg/1.1' the namespace is
extracted and used to retrieve sreg attributes.
